### PR TITLE
🐋 Switch to Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - This is a utility container
 
-FROM public.ecr.aws/docker/library/alpine:3.22@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
+FROM docker.io/alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make test
 Dependabot is configured to do this in [`.github/dependabot.yml`](.github/dependabot.yml), but if you need to get the digest, do the following
 
 ```bash
-docker pull --platform linux/amd64 public.ecr.aws/docker/library/alpine:3.22
+docker pull --platform linux/amd64 docker.io/alpine:3.22
 
-docker image inspect --format='{{ index .RepoDigests 0 }}' public.ecr.aws/docker/library/alpine:3.22
+docker image inspect --format='{{ index .RepoDigests 0 }}' docker.io/alpine:3.22
 ```

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ docker pull --platform linux/amd64 docker.io/alpine:3.22
 
 docker image inspect --format='{{ index .RepoDigests 0 }}' docker.io/alpine:3.22
 ```
+
+## Deploying
+
+After a release of this image has been created, you need to update `PodDefaults.SIDECAR_CONTAINER.image` in <https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/airflow/analytical_platform/standard_operator.py>


### PR DESCRIPTION
## Proposed Changes

- Updates Dockerfile to use Docker Hub as Dependabot is timing out when connecting to Public ECR
  - I believe its related to https://github.com/dependabot/dependabot-core/issues/11921


## :dependabot: Logs

```
updater | 2025/07/17 13:23:03 INFO <job_1055005058> Handled error whilst updating docker/library/alpine: private_source_bad_response {source: "public.ecr.aws"}
  proxy | 2025/07/17 13:23:03 [068] POST /update_jobs/1055005058/record_ecosystem_meta
  proxy | 2025/07/17 13:23:04 [068] 204 /update_jobs/1055005058/record_ecosystem_meta
  proxy | 2025/07/17 13:23:04 [070] PATCH /update_jobs/1055005058/mark_as_processed
  proxy | 2025/07/17 13:23:04 [070] 204 /update_jobs/1055005058/mark_as_processed
updater | 2025/07/17 13:23:04 INFO <job_1055005058> Finished job processing
updater | 2025/07/17 13:23:04 INFO Results:
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+------------------------------------------------------------------------------------+
|                           Dependencies failed to update                            |
+-----------------------+-----------------------------+------------------------------+
| Dependency            | Error Type                  | Error Details                |
+-----------------------+-----------------------------+------------------------------+
| docker/library/alpine | private_source_bad_response | {                            |
|                       |                             |   "source": "public.ecr.aws" |
|                       |                             | }                            |
+-----------------------+-----------------------------+------------------------------+
```

[Source](https://github.com/ministryofjustice/analytical-platform-airflow-xcom-sidecar/actions/runs/16346305415/job/46180798838) 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>