### PR TITLE
changed schedule run from 9AM to 7AM

### DIFF
--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 7 * * 1-5" # Every weekday at 7AM UTC
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -13,6 +13,7 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
+      security-events: write
     uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0
     with:
       runtime: python


### PR DESCRIPTION
Changed the schedule to run at `7 AM UTC` instead of `9 AM`, because we're using a shared runner, which doesn't guarantee the exact scheduled run time. This way, by the time our office hours start, we should already have the scan results. Also added permission for security scanning.

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/529) ticket.